### PR TITLE
Fix bug occurs after onSaveInstanceState

### DIFF
--- a/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/CardEditActivity.java
+++ b/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/CardEditActivity.java
@@ -72,12 +72,13 @@ public class CardEditActivity extends AppCompatActivity {
 
         if(savedInstanceState != null) {
             checkParams(savedInstanceState);
+            loadPager(savedInstanceState);
         }
         else {
             checkParams(getIntent().getExtras());
+            loadPager(getIntent().getExtras());
         }
 
-        loadPager();
 
         if (mStartPage > 0 && mStartPage <= CARD_NAME_PAGE) {
             getViewPager().setCurrentItem(mStartPage);
@@ -125,7 +126,7 @@ public class CardEditActivity extends AppCompatActivity {
         return (ViewPager) findViewById(R.id.card_field_container_pager);
     }
 
-    public void loadPager() {
+    public void loadPager(Bundle bundle) {
 
         ViewPager pager = getViewPager();
         pager.addOnPageChangeListener(new ViewPager.OnPageChangeListener() {
@@ -154,7 +155,7 @@ public class CardEditActivity extends AppCompatActivity {
         });
         pager.setOffscreenPageLimit(4);
 
-        mCardAdapter = new CardFragmentAdapter(getSupportFragmentManager(),getIntent().getExtras());
+        mCardAdapter = new CardFragmentAdapter(getSupportFragmentManager(), bundle);
         mCardAdapter.setOnCardEntryCompleteListener(new ICardEntryCompleteListener() {
             @Override
             public void onCardEntryComplete(int currentIndex) {

--- a/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/pager/CardFragmentAdapter.java
+++ b/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/pager/CardFragmentAdapter.java
@@ -1,6 +1,7 @@
 package com.cooltechworks.creditcarddesign.pager;
 
 import android.os.Bundle;
+import android.os.Parcelable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
@@ -99,5 +100,10 @@ public class CardFragmentAdapter extends FragmentStatePagerAdapter implements IA
         if (index >= 0 && mCardEntryCompleteListener != null) {
             mCardEntryCompleteListener.onCardEntryEdit(index, edit);
         }
+    }
+
+    @Override
+    public void restoreState(Parcelable parcelable, ClassLoader classLoader) {
+        //do nothing here! no call to super.restoreState(parcelable, classLoader);
     }
 }


### PR DESCRIPTION
After activity restart (e.g. when a user has set "Don't keep activities" checkbox in Developer's settings) this library is not working properly.