### PR TITLE
Added support for AMEX cards (15 digits, CVV on the front)

### DIFF
--- a/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/CardSelector.java
+++ b/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/CardSelector.java
@@ -10,10 +10,6 @@ public class CardSelector {
     public static final CardSelector AMEX = new CardSelector(R.drawable.card_color_round_rect_green, android.R.color.transparent, android.R.color.transparent, R.drawable.img_amex_center_face, R.drawable.ic_billing_amex_logo1, CardSelector.CVV_LENGHT_AMEX);
     public static final CardSelector DEFAULT = new CardSelector(R.drawable.card_color_round_rect_default, R.drawable.chip, R.drawable.chip_inner, android.R.color.transparent, android.R.color.transparent, CardSelector.CVV_LENGHT_DEFAULT);
 
-    private static final char PREFIX_AMEX = '3';
-    private static final char PREFIX_VISA = '4';
-    private static final char PREFIX_MASTER = '5';
-
     public static final int CVV_LENGHT_DEFAULT = 3;
     public static final int CVV_LENGHT_AMEX = 4;
 
@@ -82,24 +78,25 @@ public class CardSelector {
         this.mCvvLength = mCvvLength;
     }
 
-    public static CardSelector selectCard(char cardFirstChar) {
-        switch (cardFirstChar) {
-            case PREFIX_VISA:
-                return VISA;
-            case PREFIX_MASTER:
-                return MASTER;
-            case PREFIX_AMEX:
+    public static CardSelector selectCardType(CreditCardUtils.CardType cardType) {
+        switch(cardType) {
+            case AMEX_CARD:
                 return AMEX;
+            case MASTER_CARD:
+                return MASTER;
+            case VISA_CARD:
+                return VISA;
             default:
                 return DEFAULT;
         }
     }
 
     public static CardSelector selectCard(String cardNumber) {
-        if (cardNumber != null && cardNumber.length() >= 3) {
-            CardSelector selector = selectCard(cardNumber.charAt(0));
+        if (cardNumber != null && cardNumber.length() >= 1) {
+            CreditCardUtils.CardType cardType = CreditCardUtils.selectCardType(cardNumber);
+            CardSelector selector = selectCardType(cardType);
 
-            if (selector != DEFAULT) {
+            if ((selector != DEFAULT) && (cardNumber.length() >= 3)) {
                 int[] drawables = {R.drawable.card_color_round_rect_brown, R.drawable.card_color_round_rect_green, R.drawable.card_color_round_rect_pink, R.drawable.card_color_round_rect_purple, R.drawable.card_color_round_rect_blue};
                 int hash = cardNumber.substring(0, 3).hashCode();
 

--- a/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/CreditCardView.java
+++ b/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/CreditCardView.java
@@ -27,6 +27,7 @@ public class CreditCardView extends FrameLayout {
     private static final int TEXTVIEW_CARD_EXPIRY_ID = R.id.front_card_expiry;
     private static final int TEXTVIEW_CARD_NUMBER_ID = R.id.front_card_number;
     private static final int TEXTVIEW_CARD_CVV_ID = R.id.back_card_cvv;
+    private static final int TEXTVIEW_CARD_CVV_AMEX_ID = R.id.front_card_cvv;
     private static final int FRONT_CARD_ID = R.id.front_card_container;
     private static final int BACK_CARD_ID = R.id.back_card_container;
     private static final int FRONT_CARD_OUTLINE_ID = R.id.front_card_outline;
@@ -38,6 +39,8 @@ public class CreditCardView extends FrameLayout {
     private ICustomCardSelector mSelectorLogic;
 
     private String mCardHolderName, mCVV, mExpiry;
+
+    private CreditCardUtils.CardType mCardType;
 
     int mCardnameLen;
 
@@ -68,6 +71,8 @@ public class CreditCardView extends FrameLayout {
         return mExpiry;
     }
 
+    public CreditCardUtils.CardType getCardType() { return mCardType; }
+
     interface ICustomCardSelector {
         CardSelector getCardSelector(String cardNumber);
     }
@@ -94,6 +99,7 @@ public class CreditCardView extends FrameLayout {
         String cardHolderName = a.getString(R.styleable.creditcard_card_holder_name);
         String expiry = a.getString(R.styleable.creditcard_card_expiration);
         String cardNumber = a.getString(R.styleable.creditcard_card_number);
+
         int cvv = a.getInt(R.styleable.creditcard_cvv, 0);
         int cardSide = a.getInt(R.styleable.creditcard_card_side,CreditCardUtils.CARD_SIDE_FRONT);
 
@@ -165,17 +171,19 @@ public class CreditCardView extends FrameLayout {
 
 
         this.mRawCardNumber = rawCardNumber == null ? "" : rawCardNumber;
+        this.mCardType = CreditCardUtils.selectCardType(this.mRawCardNumber);
+        String cardNumber = CreditCardUtils.formatCardNumber(this.mRawCardNumber, CreditCardUtils.SPACE_SEPERATOR);
 
-        String newCardNumber = mRawCardNumber;
-        for(int i=mRawCardNumber.length();i<16;i++) {
-            newCardNumber +=CreditCardUtils.CHAR_X;
-        }
-
-        String cardNumber = CreditCardUtils.handleCardNumber(newCardNumber, CreditCardUtils.DOUBLE_SPACE_SEPERATOR);
         ((TextView)findViewById(TEXTVIEW_CARD_NUMBER_ID)).setText(cardNumber);
+        ((TextView)findViewById(TEXTVIEW_CARD_CVV_AMEX_ID)).setVisibility(mCardType == CreditCardUtils.CardType.AMEX_CARD ? View.VISIBLE : View.GONE);
 
-        if(mRawCardNumber.length() == 3) {
-            revealCardAnimation();
+        if(this.mCardType != CreditCardUtils.CardType.UNKNOWN_CARD) {
+            this.post(new Runnable() {
+                @Override
+                public void run() {
+                    revealCardAnimation();
+                }
+            });
         }
         else {
             paintCard();
@@ -218,6 +226,7 @@ public class CreditCardView extends FrameLayout {
 
         this.mCVV = cvv;
         ((TextView)findViewById(TEXTVIEW_CARD_CVV_ID)).setText(cvv);
+        ((TextView)findViewById(TEXTVIEW_CARD_CVV_AMEX_ID)).setText(cvv);
     }
 
     public void setCardExpiry(String dateYear) {

--- a/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/pager/CardCVVFragment.java
+++ b/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/pager/CardCVVFragment.java
@@ -60,7 +60,7 @@ public class CardCVVFragment extends CreditCardFragment {
     }
 
     public void setMaxCVV(int maxCVVLength) {
-        if (mCardCVVView != null && mCardCVVView.getText().toString().length() >= maxCVVLength) {
+        if (mCardCVVView != null && (mCardCVVView.getText().toString().length() > maxCVVLength)) {
             mCardCVVView.setText(mCardCVVView.getText().toString().substring(0, maxCVVLength));
         }
 

--- a/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/pager/CardNumberFragment.java
+++ b/creditcarddesign/src/main/java/com/cooltechworks/creditcarddesign/pager/CardNumberFragment.java
@@ -10,9 +10,9 @@ import android.widget.EditText;
 import com.cooltechworks.creditcarddesign.CreditCardUtils;
 import com.cooltechworks.creditcarddesign.R;
 
+import static com.cooltechworks.creditcarddesign.CreditCardUtils.CARD_NUMBER_FORMAT;
+import static com.cooltechworks.creditcarddesign.CreditCardUtils.CARD_NUMBER_FORMAT_AMEX;
 import static com.cooltechworks.creditcarddesign.CreditCardUtils.EXTRA_CARD_NUMBER;
-import static com.cooltechworks.creditcarddesign.CreditCardUtils.MAX_LENGTH_CARD_NUMBER;
-import static com.cooltechworks.creditcarddesign.CreditCardUtils.MAX_LENGTH_CARD_NUMBER_WITH_SPACES;
 
 /**
  * Created by sharish on 9/1/15.
@@ -55,7 +55,10 @@ public class CardNumberFragment extends CreditCardFragment {
 
         mCardNumberView.removeTextChangedListener(this);
         mCardNumberView.setText(cardNumber);
-        mCardNumberView.setSelection(cardNumber.length() > MAX_LENGTH_CARD_NUMBER_WITH_SPACES ? MAX_LENGTH_CARD_NUMBER_WITH_SPACES : cardNumber.length());
+        String rawCardNumber = cardNumber.replace(CreditCardUtils.SPACE_SEPERATOR, "");
+        CreditCardUtils.CardType cardType = CreditCardUtils.selectCardType(rawCardNumber);
+        int maxLengthWithSpaces = ((cardType == CreditCardUtils.CardType.AMEX_CARD) ? CARD_NUMBER_FORMAT_AMEX : CARD_NUMBER_FORMAT).length();
+        mCardNumberView.setSelection(cardNumber.length() > maxLengthWithSpaces ? maxLengthWithSpaces : cardNumber.length());
         mCardNumberView.addTextChangedListener(this);
 
         if (modifiedLength <= previousLength && cursorPosition < modifiedLength) {
@@ -64,7 +67,7 @@ public class CardNumberFragment extends CreditCardFragment {
 
         onEdit(cardNumber);
 
-        if (cardNumber.replace(CreditCardUtils.SPACE_SEPERATOR, "").length() == MAX_LENGTH_CARD_NUMBER) {
+        if (rawCardNumber.length() == CreditCardUtils.selectCardLength(cardType)) {
             onComplete();
         }
     }

--- a/creditcarddesign/src/main/res/layout/front_card.xml
+++ b/creditcarddesign/src/main/res/layout/front_card.xml
@@ -6,6 +6,34 @@
     android:orientation="vertical"
     >
 
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="60dp"
+        android:layout_marginLeft="250dp"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/front_card_cvv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:hint="@string/hint_cvv_front"
+            android:maxWidth="60dp"
+            android:minWidth="60dp"
+            android:paddingBottom="@dimen/padding_small"
+            android:paddingTop="@dimen/padding_small"
+            android:shadowColor="@color/text_shadow"
+            android:shadowDx="1"
+            android:shadowDy="1"
+            android:shadowRadius="2"
+            android:textColor="@android:color/white"
+            android:textColorHint="@color/semi_white"
+            android:visibility="gone"
+            />
+
+    </LinearLayout>
+
     <TextView
         android:id="@+id/front_card_number"
         android:layout_width="wrap_content"

--- a/creditcarddesign/src/main/res/values/strings.xml
+++ b/creditcarddesign/src/main/res/values/strings.xml
@@ -13,9 +13,10 @@
     <string name="mm_yy">MM/YY</string>
     <string name="card_expiry">CARD EXPIRY</string>
     <string name="card_mm_yy">MM/YY</string>
+    <string name="hint_cvv_front">0000</string>
     <string name="name_on_card">NAME ON CARD</string>
     <string name="card_number">CARD NUMBER</string>
     <string name="error_invalid_month">Invalid month</string>
     <string name="error_card_expired">Card expired</string>
-    <integer name="card_name_len">16</integer>
+    <integer name="card_name_len">25</integer>
 </resources>


### PR DESCRIPTION
Short of a rewrite to abstract some of the credit card type-specific variations, the changes I have implemented in this PR add support for AMEX cards. The highlights are: 15 digits, different grouping of the digits, the CVV is on the front (thus, don't flip the card). I also made some miscellaneous fixes that in some cases would cause fatal exceptions or unwanted degradation in the support of the AMEX cards (such as switching back to 3-digit CVV).

There are still many things I changed in my local repo that I did not include with this PR, such as the card color and chip layout being changed even after the card type has been identified. I would want to keep the Amex card green and not have it change color yet again. There are other chicken and egg issues with the code, such as setting the max CVV length when the underlying view object is still null. Again, a rewrite is in order. One has to separate the model logic from the UI.

Anyway, I hope this helps some folks out there who are wanting a better visualization of the AmEx cards.